### PR TITLE
Update gh-advanced-security.md

### DIFF
--- a/study-guides/gh-advanced-security.md
+++ b/study-guides/gh-advanced-security.md
@@ -375,9 +375,7 @@ Align repository branch protection configuration with written security policies
 ```
 
 
-```
-GitHub Advanced Security Administration
-```
+## Domain 7: GitHub Advanced Security Administration
 ```
 Explain how GitHub Advanced Security features are enabled on GitHub Enterprise Server
 ```


### PR DESCRIPTION
The header for Domain 7: GitHub Advanced Security Administration was missing @LadyKerr 